### PR TITLE
Remove unneeded `node_modules/.bin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ We can utilise this feature of ESNext to our advantage, by publishing both the E
 		``` json
 		{
 			"scripts": {
-				"compile": "./node_modules/.bin/babel esnext --out-dir es5"
+				"compile": "babel esnext --out-dir es5"
 			}
 		}
 		```


### PR DESCRIPTION
npm scripts have their `node_modules/.bin` added to the `PATH` automatically, and so calls to things provided by dependencies have no need to be prefixed by `node_modules/.bin`.
